### PR TITLE
Add basic inventory resources

### DIFF
--- a/app/Filament/Resources/BrandResource.php
+++ b/app/Filament/Resources/BrandResource.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\BrandResource\Pages;
+use App\Models\Brand;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class BrandResource extends Resource
+{
+    protected static ?string $model = Brand::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationGroup = 'Products';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('name')
+                    ->required()
+                    ->unique(ignoreRecord: true)
+                    ->maxLength(255),
+                Forms\Components\TextInput::make('contact_person')
+                    ->maxLength(255),
+                Forms\Components\TextInput::make('phone')
+                    ->maxLength(255),
+                Forms\Components\Textarea::make('address')
+                    ->columnSpanFull(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')->searchable(),
+                Tables\Columns\TextColumn::make('contact_person')->searchable(),
+                Tables\Columns\TextColumn::make('phone')->searchable(),
+                Tables\Columns\TextColumn::make('address')->wrap(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListBrands::route('/'),
+            'create' => Pages\CreateBrand::route('/create'),
+            'edit' => Pages\EditBrand::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/BrandResource/Pages/CreateBrand.php
+++ b/app/Filament/Resources/BrandResource/Pages/CreateBrand.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\BrandResource\Pages;
+
+use App\Filament\Resources\BrandResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateBrand extends CreateRecord
+{
+    protected static string $resource = BrandResource::class;
+}

--- a/app/Filament/Resources/BrandResource/Pages/EditBrand.php
+++ b/app/Filament/Resources/BrandResource/Pages/EditBrand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\BrandResource\Pages;
+
+use App\Filament\Resources\BrandResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditBrand extends EditRecord
+{
+    protected static string $resource = BrandResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/BrandResource/Pages/ListBrands.php
+++ b/app/Filament/Resources/BrandResource/Pages/ListBrands.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\BrandResource\Pages;
+
+use App\Filament\Resources\BrandResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListBrands extends ListRecords
+{
+    protected static string $resource = BrandResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/CategoryResource.php
+++ b/app/Filament/Resources/CategoryResource.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\CategoryResource\Pages;
+use App\Models\Category;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class CategoryResource extends Resource
+{
+    protected static ?string $model = Category::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationGroup = 'Products';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('name')
+                    ->required()
+                    ->unique(ignoreRecord: true)
+                    ->maxLength(255),
+                Forms\Components\TextInput::make('box_pcs')
+                    ->integer()
+                    ->minValue(0)
+                    ->nullable(),
+                Forms\Components\TextInput::make('pieces_feet')
+                    ->numeric()
+                    ->minValue(0)
+                    ->step(0.0001)
+                    ->nullable(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')->searchable(),
+                Tables\Columns\TextColumn::make('box_pcs'),
+                Tables\Columns\TextColumn::make('pieces_feet'),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListCategories::route('/'),
+            'create' => Pages\CreateCategory::route('/create'),
+            'edit' => Pages\EditCategory::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/CategoryResource/Pages/CreateCategory.php
+++ b/app/Filament/Resources/CategoryResource/Pages/CreateCategory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\CategoryResource\Pages;
+
+use App\Filament\Resources\CategoryResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateCategory extends CreateRecord
+{
+    protected static string $resource = CategoryResource::class;
+}

--- a/app/Filament/Resources/CategoryResource/Pages/EditCategory.php
+++ b/app/Filament/Resources/CategoryResource/Pages/EditCategory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\CategoryResource\Pages;
+
+use App\Filament\Resources\CategoryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditCategory extends EditRecord
+{
+    protected static string $resource = CategoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/CategoryResource/Pages/ListCategories.php
+++ b/app/Filament/Resources/CategoryResource/Pages/ListCategories.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\CategoryResource\Pages;
+
+use App\Filament\Resources\CategoryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListCategories extends ListRecords
+{
+    protected static string $resource = CategoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/DamageProductResource.php
+++ b/app/Filament/Resources/DamageProductResource.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\DamageProductResource\Pages;
+use App\Models\DamageProduct;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class DamageProductResource extends Resource
+{
+    protected static ?string $model = DamageProduct::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationGroup = 'Products';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('product_id')
+                    ->relationship('product', 'name')
+                    ->required(),
+                Forms\Components\Select::make('warehouse_id')
+                    ->relationship('warehouse', 'name')
+                    ->required(),
+                Forms\Components\TextInput::make('quantity')->numeric()->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('product.name')->label('Product'),
+                Tables\Columns\TextColumn::make('warehouse.name')->label('Warehouse'),
+                Tables\Columns\TextColumn::make('quantity'),
+                Tables\Columns\TextColumn::make('created_at')->dateTime(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDamageProducts::route('/'),
+            'create' => Pages\CreateDamageProduct::route('/create'),
+            'edit' => Pages\EditDamageProduct::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/DamageProductResource/Pages/CreateDamageProduct.php
+++ b/app/Filament/Resources/DamageProductResource/Pages/CreateDamageProduct.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\DamageProductResource\Pages;
+
+use App\Filament\Resources\DamageProductResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDamageProduct extends CreateRecord
+{
+    protected static string $resource = DamageProductResource::class;
+}

--- a/app/Filament/Resources/DamageProductResource/Pages/EditDamageProduct.php
+++ b/app/Filament/Resources/DamageProductResource/Pages/EditDamageProduct.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\DamageProductResource\Pages;
+
+use App\Filament\Resources\DamageProductResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDamageProduct extends EditRecord
+{
+    protected static string $resource = DamageProductResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/DamageProductResource/Pages/ListDamageProducts.php
+++ b/app/Filament/Resources/DamageProductResource/Pages/ListDamageProducts.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\DamageProductResource\Pages;
+
+use App\Filament\Resources\DamageProductResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDamageProducts extends ListRecords
+{
+    protected static string $resource = DamageProductResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ProductMovementResource.php
+++ b/app/Filament/Resources/ProductMovementResource.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ProductMovementResource\Pages;
+use App\Models\ProductMovement;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class ProductMovementResource extends Resource
+{
+    protected static ?string $model = ProductMovement::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationGroup = 'Products';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('product_id')
+                    ->relationship('product', 'name')
+                    ->required(),
+                Forms\Components\TextInput::make('type')->required()->maxLength(255),
+                Forms\Components\TextInput::make('quantity')->numeric()->required(),
+                Forms\Components\Textarea::make('description')->columnSpanFull(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('product.name')->label('Product'),
+                Tables\Columns\TextColumn::make('type'),
+                Tables\Columns\TextColumn::make('quantity'),
+                Tables\Columns\TextColumn::make('created_at')->dateTime(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListProductMovements::route('/'),
+            'create' => Pages\CreateProductMovement::route('/create'),
+            'edit' => Pages\EditProductMovement::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ProductMovementResource/Pages/CreateProductMovement.php
+++ b/app/Filament/Resources/ProductMovementResource/Pages/CreateProductMovement.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ProductMovementResource\Pages;
+
+use App\Filament\Resources\ProductMovementResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateProductMovement extends CreateRecord
+{
+    protected static string $resource = ProductMovementResource::class;
+}

--- a/app/Filament/Resources/ProductMovementResource/Pages/EditProductMovement.php
+++ b/app/Filament/Resources/ProductMovementResource/Pages/EditProductMovement.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\ProductMovementResource\Pages;
+
+use App\Filament\Resources\ProductMovementResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditProductMovement extends EditRecord
+{
+    protected static string $resource = ProductMovementResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ProductMovementResource/Pages/ListProductMovements.php
+++ b/app/Filament/Resources/ProductMovementResource/Pages/ListProductMovements.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\ProductMovementResource\Pages;
+
+use App\Filament\Resources\ProductMovementResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListProductMovements extends ListRecords
+{
+    protected static string $resource = ProductMovementResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ProductResource.php
+++ b/app/Filament/Resources/ProductResource.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ProductResource\Pages;
+use App\Models\Product;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class ProductResource extends Resource
+{
+    protected static ?string $model = Product::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationGroup = 'Products';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('name')->required()->maxLength(255),
+                Forms\Components\TextInput::make('code')->required()->maxLength(255)->unique(ignoreRecord: true),
+                Forms\Components\Select::make('brand_id')
+                    ->relationship('brand', 'name')
+                    ->createOptionForm([
+                        Forms\Components\TextInput::make('name')->required()->unique()->maxLength(255),
+                    ])
+                    ->required(),
+                Forms\Components\Select::make('category_id')
+                    ->relationship('category', 'name')
+                    ->createOptionForm([
+                        Forms\Components\TextInput::make('name')->required()->unique()->maxLength(255),
+                    ])
+                    ->required(),
+                Forms\Components\Select::make('unit_id')
+                    ->relationship('unit', 'name')
+                    ->createOptionForm([
+                        Forms\Components\TextInput::make('name')->required()->unique()->maxLength(255),
+                        Forms\Components\Toggle::make('is_active')->default(true),
+                    ])
+                    ->required(),
+                Forms\Components\Textarea::make('description')->columnSpanFull(),
+                Forms\Components\TextInput::make('purchase_price')->numeric()->required(),
+                Forms\Components\TextInput::make('sales_price')->numeric()->required(),
+                Forms\Components\TextInput::make('alert_quantity')->numeric()->default(0),
+                Forms\Components\Toggle::make('track_inventory')->label('Track Inventory')->default(true),
+                Forms\Components\TextInput::make('opening_quantity')
+                    ->numeric()
+                    ->default(0)
+                    ->visible(fn ($get) => $get('track_inventory')),
+                Forms\Components\Toggle::make('is_active')->label('Active')->default(true),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')->searchable(),
+                Tables\Columns\TextColumn::make('brand.name')->label('Brand')->sortable(),
+                Tables\Columns\TextColumn::make('category.name')->label('Category')->sortable(),
+                Tables\Columns\TextColumn::make('unit.name')->label('Unit')->sortable(),
+                Tables\Columns\TextColumn::make('purchase_price')->money('usd'),
+                Tables\Columns\TextColumn::make('sales_price')->money('usd'),
+                Tables\Columns\TextColumn::make('current_quantity')->label('Stock')->numeric()->sortable(),
+                Tables\Columns\IconColumn::make('is_active')->boolean(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListProducts::route('/'),
+            'create' => Pages\CreateProduct::route('/create'),
+            'edit' => Pages\EditProduct::route('/{record}/edit'),
+        ];
+    }
+
+    public static function mutateFormDataBeforeCreate(array $data): array
+    {
+        if (!($data['track_inventory'] ?? true)) {
+            $data['opening_quantity'] = 0;
+            $data['current_quantity'] = 0;
+        } else {
+            $data['current_quantity'] = $data['opening_quantity'] ?? 0;
+        }
+
+        return $data;
+    }
+
+    public static function mutateFormDataBeforeSave(array $data): array
+    {
+        if (!($data['track_inventory'] ?? true)) {
+            $data['opening_quantity'] = 0;
+            $data['current_quantity'] = 0;
+        }
+
+        return $data;
+    }
+}

--- a/app/Filament/Resources/ProductResource/Pages/CreateProduct.php
+++ b/app/Filament/Resources/ProductResource/Pages/CreateProduct.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ProductResource\Pages;
+
+use App\Filament\Resources\ProductResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateProduct extends CreateRecord
+{
+    protected static string $resource = ProductResource::class;
+}

--- a/app/Filament/Resources/ProductResource/Pages/EditProduct.php
+++ b/app/Filament/Resources/ProductResource/Pages/EditProduct.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\ProductResource\Pages;
+
+use App\Filament\Resources\ProductResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditProduct extends EditRecord
+{
+    protected static string $resource = ProductResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ProductResource/Pages/ListProducts.php
+++ b/app/Filament/Resources/ProductResource/Pages/ListProducts.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Filament\Resources\ProductResource\Pages;
+
+use App\Filament\Resources\ProductResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListProducts extends ListRecords
+{
+    protected static string $resource = ProductResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+            Actions\ExportAction::make('export_all')->label('Export All'),
+        ];
+    }
+}

--- a/app/Filament/Resources/SupplierResource.php
+++ b/app/Filament/Resources/SupplierResource.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\SupplierResource\Pages;
+use App\Models\Supplier;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class SupplierResource extends Resource
+{
+    protected static ?string $model = Supplier::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationGroup = 'Products';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('name')
+                    ->required()
+                    ->maxLength(255),
+                Forms\Components\TextInput::make('phone')
+                    ->maxLength(255),
+                Forms\Components\TextInput::make('opening_balance')
+                    ->numeric()
+                    ->default(0),
+                Forms\Components\TextInput::make('current_balance')
+                    ->numeric()
+                    ->default(0),
+                Forms\Components\DatePicker::make('payment_date')
+                    ->nullable(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')->searchable(),
+                Tables\Columns\TextColumn::make('phone'),
+                Tables\Columns\TextColumn::make('current_balance')->money('usd'),
+                Tables\Columns\TextColumn::make('payment_date')
+                    ->date()
+                    ->label('Payment Due'),
+                Tables\Columns\BadgeColumn::make('payment_status')
+                    ->label('Status')
+                    ->colors(['danger' => fn ($record) => $record->payment_date && $record->payment_date->isPast()])
+                    ->formatStateUsing(fn ($record) => $record->payment_date && $record->payment_date->isPast() ? 'Overdue' : 'OK'),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListSuppliers::route('/'),
+            'create' => Pages\CreateSupplier::route('/create'),
+            'edit' => Pages\EditSupplier::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/SupplierResource/Pages/CreateSupplier.php
+++ b/app/Filament/Resources/SupplierResource/Pages/CreateSupplier.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\SupplierResource\Pages;
+
+use App\Filament\Resources\SupplierResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateSupplier extends CreateRecord
+{
+    protected static string $resource = SupplierResource::class;
+}

--- a/app/Filament/Resources/SupplierResource/Pages/EditSupplier.php
+++ b/app/Filament/Resources/SupplierResource/Pages/EditSupplier.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\SupplierResource\Pages;
+
+use App\Filament\Resources\SupplierResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditSupplier extends EditRecord
+{
+    protected static string $resource = SupplierResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/SupplierResource/Pages/ListSuppliers.php
+++ b/app/Filament/Resources/SupplierResource/Pages/ListSuppliers.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\SupplierResource\Pages;
+
+use App\Filament\Resources\SupplierResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListSuppliers extends ListRecords
+{
+    protected static string $resource = SupplierResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/UnitResource.php
+++ b/app/Filament/Resources/UnitResource.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\UnitResource\Pages;
+use App\Models\Unit;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class UnitResource extends Resource
+{
+    protected static ?string $model = Unit::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationGroup = 'Products';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('name')
+                    ->required()
+                    ->unique(ignoreRecord: true)
+                    ->maxLength(255),
+                Forms\Components\Toggle::make('is_active')
+                    ->label('Active')
+                    ->default(true),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')->searchable(),
+                Tables\Columns\IconColumn::make('is_active')
+                    ->boolean(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListUnits::route('/'),
+            'create' => Pages\CreateUnit::route('/create'),
+            'edit' => Pages\EditUnit::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/UnitResource/Pages/CreateUnit.php
+++ b/app/Filament/Resources/UnitResource/Pages/CreateUnit.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\UnitResource\Pages;
+
+use App\Filament\Resources\UnitResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateUnit extends CreateRecord
+{
+    protected static string $resource = UnitResource::class;
+}

--- a/app/Filament/Resources/UnitResource/Pages/EditUnit.php
+++ b/app/Filament/Resources/UnitResource/Pages/EditUnit.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\UnitResource\Pages;
+
+use App\Filament\Resources\UnitResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditUnit extends EditRecord
+{
+    protected static string $resource = UnitResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/UnitResource/Pages/ListUnits.php
+++ b/app/Filament/Resources/UnitResource/Pages/ListUnits.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\UnitResource\Pages;
+
+use App\Filament\Resources\UnitResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListUnits extends ListRecords
+{
+    protected static string $resource = UnitResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/WarehouseResource.php
+++ b/app/Filament/Resources/WarehouseResource.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\WarehouseResource\Pages;
+use App\Models\Warehouse;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class WarehouseResource extends Resource
+{
+    protected static ?string $model = Warehouse::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationGroup = 'Settings';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('name')
+                    ->required()
+                    ->unique(ignoreRecord: true)
+                    ->maxLength(255),
+                Forms\Components\Textarea::make('address')
+                    ->columnSpanFull(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')->searchable(),
+                Tables\Columns\TextColumn::make('address')->wrap(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListWarehouses::route('/'),
+            'create' => Pages\CreateWarehouse::route('/create'),
+            'edit' => Pages\EditWarehouse::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/WarehouseResource/Pages/CreateWarehouse.php
+++ b/app/Filament/Resources/WarehouseResource/Pages/CreateWarehouse.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\WarehouseResource\Pages;
+
+use App\Filament\Resources\WarehouseResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateWarehouse extends CreateRecord
+{
+    protected static string $resource = WarehouseResource::class;
+}

--- a/app/Filament/Resources/WarehouseResource/Pages/EditWarehouse.php
+++ b/app/Filament/Resources/WarehouseResource/Pages/EditWarehouse.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\WarehouseResource\Pages;
+
+use App\Filament\Resources\WarehouseResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditWarehouse extends EditRecord
+{
+    protected static string $resource = WarehouseResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/WarehouseResource/Pages/ListWarehouses.php
+++ b/app/Filament/Resources/WarehouseResource/Pages/ListWarehouses.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\WarehouseResource\Pages;
+
+use App\Filament\Resources\WarehouseResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListWarehouses extends ListRecords
+{
+    protected static string $resource = WarehouseResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/WarrantyProductResource.php
+++ b/app/Filament/Resources/WarrantyProductResource.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\WarrantyProductResource\Pages;
+use App\Models\WarrantyProduct;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class WarrantyProductResource extends Resource
+{
+    protected static ?string $model = WarrantyProduct::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationGroup = 'Products';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('product_id')
+                    ->relationship('product', 'name')
+                    ->required(),
+                Forms\Components\Select::make('warehouse_id')
+                    ->relationship('warehouse', 'name')
+                    ->required(),
+                Forms\Components\TextInput::make('customer_name')->maxLength(255),
+                Forms\Components\DatePicker::make('warranty_date'),
+                Forms\Components\TextInput::make('quantity')->numeric()->required(),
+                Forms\Components\Toggle::make('resolved')->default(false),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('product.name')->label('Product'),
+                Tables\Columns\TextColumn::make('warehouse.name')->label('Warehouse'),
+                Tables\Columns\TextColumn::make('customer_name'),
+                Tables\Columns\TextColumn::make('warranty_date')->date(),
+                Tables\Columns\TextColumn::make('quantity'),
+                Tables\Columns\IconColumn::make('resolved')->boolean(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListWarrantyProducts::route('/'),
+            'create' => Pages\CreateWarrantyProduct::route('/create'),
+            'edit' => Pages\EditWarrantyProduct::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/WarrantyProductResource/Pages/CreateWarrantyProduct.php
+++ b/app/Filament/Resources/WarrantyProductResource/Pages/CreateWarrantyProduct.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\WarrantyProductResource\Pages;
+
+use App\Filament\Resources\WarrantyProductResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateWarrantyProduct extends CreateRecord
+{
+    protected static string $resource = WarrantyProductResource::class;
+}

--- a/app/Filament/Resources/WarrantyProductResource/Pages/EditWarrantyProduct.php
+++ b/app/Filament/Resources/WarrantyProductResource/Pages/EditWarrantyProduct.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\WarrantyProductResource\Pages;
+
+use App\Filament\Resources\WarrantyProductResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditWarrantyProduct extends EditRecord
+{
+    protected static string $resource = WarrantyProductResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/WarrantyProductResource/Pages/ListWarrantyProducts.php
+++ b/app/Filament/Resources/WarrantyProductResource/Pages/ListWarrantyProducts.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\WarrantyProductResource\Pages;
+
+use App\Filament\Resources\WarrantyProductResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListWarrantyProducts extends ListRecords
+{
+    protected static string $resource = WarrantyProductResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Models/Brand.php
+++ b/app/Models/Brand.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Brand extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'contact_person',
+        'phone',
+        'address',
+    ];
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Category extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'box_pcs',
+        'pieces_feet',
+    ];
+}

--- a/app/Models/DamageProduct.php
+++ b/app/Models/DamageProduct.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DamageProduct extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'product_id',
+        'warehouse_id',
+        'quantity',
+    ];
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function warehouse()
+    {
+        return $this->belongsTo(Warehouse::class);
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'code',
+        'brand_id',
+        'category_id',
+        'unit_id',
+        'description',
+        'purchase_price',
+        'sales_price',
+        'alert_quantity',
+        'is_active',
+        'track_inventory',
+        'opening_quantity',
+        'current_quantity',
+    ];
+
+    public function brand()
+    {
+        return $this->belongsTo(Brand::class);
+    }
+
+    public function category()
+    {
+        return $this->belongsTo(Category::class);
+    }
+
+    public function unit()
+    {
+        return $this->belongsTo(Unit::class);
+    }
+}

--- a/app/Models/ProductMovement.php
+++ b/app/Models/ProductMovement.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ProductMovement extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'product_id',
+        'type',
+        'quantity',
+        'description',
+    ];
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Supplier extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'phone',
+        'opening_balance',
+        'current_balance',
+        'payment_date',
+    ];
+}

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Unit extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'is_active',
+    ];
+}

--- a/app/Models/Warehouse.php
+++ b/app/Models/Warehouse.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Warehouse extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'address',
+    ];
+}

--- a/app/Models/WarrantyProduct.php
+++ b/app/Models/WarrantyProduct.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class WarrantyProduct extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'product_id',
+        'warehouse_id',
+        'customer_name',
+        'warranty_date',
+        'quantity',
+        'resolved',
+    ];
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function warehouse()
+    {
+        return $this->belongsTo(Warehouse::class);
+    }
+}

--- a/database/migrations/2025_07_07_191802_create_brands_table.php
+++ b/database/migrations/2025_07_07_191802_create_brands_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('brands', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('contact_person')->nullable();
+            $table->string('phone')->nullable();
+            $table->text('address')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('brands');
+    }
+};

--- a/database/migrations/2025_07_07_193855_create_categories_table.php
+++ b/database/migrations/2025_07_07_193855_create_categories_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->integer('box_pcs')->nullable();
+            $table->decimal('pieces_feet', 8, 4)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2025_07_07_202820_create_units_table.php
+++ b/database/migrations/2025_07_07_202820_create_units_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('units', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('units');
+    }
+};

--- a/database/migrations/2025_07_07_202822_create_suppliers_table.php
+++ b/database/migrations/2025_07_07_202822_create_suppliers_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('suppliers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('phone')->nullable();
+            $table->decimal('opening_balance', 15, 2)->default(0);
+            $table->decimal('current_balance', 15, 2)->default(0);
+            $table->date('payment_date')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('suppliers');
+    }
+};

--- a/database/migrations/2025_07_07_202824_create_warehouses_table.php
+++ b/database/migrations/2025_07_07_202824_create_warehouses_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('warehouses', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->text('address')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('warehouses');
+    }
+};

--- a/database/migrations/2025_07_07_202827_create_products_table.php
+++ b/database/migrations/2025_07_07_202827_create_products_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('code')->unique();
+            $table->foreignId('brand_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('category_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('unit_id')->constrained()->cascadeOnDelete();
+            $table->text('description')->nullable();
+            $table->decimal('purchase_price', 15, 2);
+            $table->decimal('sales_price', 15, 2);
+            $table->integer('alert_quantity')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+};

--- a/database/migrations/2025_07_07_202829_create_damage_products_table.php
+++ b/database/migrations/2025_07_07_202829_create_damage_products_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('damage_products', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('warehouse_id')->constrained()->cascadeOnDelete();
+            $table->integer('quantity');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('damage_products');
+    }
+};

--- a/database/migrations/2025_07_07_202831_create_warranty_products_table.php
+++ b/database/migrations/2025_07_07_202831_create_warranty_products_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('warranty_products', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('warehouse_id')->constrained()->cascadeOnDelete();
+            $table->string('customer_name')->nullable();
+            $table->date('warranty_date')->nullable();
+            $table->integer('quantity');
+            $table->boolean('resolved')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('warranty_products');
+    }
+};

--- a/database/migrations/2025_07_07_202833_create_product_warehouse_table.php
+++ b/database/migrations/2025_07_07_202833_create_product_warehouse_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('product_warehouse', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('warehouse_id')->constrained()->cascadeOnDelete();
+            $table->integer('opening_quantity')->default(0);
+            $table->integer('current_quantity')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('product_warehouse');
+    }
+};

--- a/database/migrations/2025_07_07_202836_create_product_movements_table.php
+++ b/database/migrations/2025_07_07_202836_create_product_movements_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('product_movements', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->string('type');
+            $table->integer('quantity');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('product_movements');
+    }
+};

--- a/database/migrations/2025_07_07_203100_add_inventory_fields_to_products_table.php
+++ b/database/migrations/2025_07_07_203100_add_inventory_fields_to_products_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->boolean('track_inventory')->default(true);
+            $table->integer('opening_quantity')->default(0);
+            $table->integer('current_quantity')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn(['track_inventory', 'opening_quantity', 'current_quantity']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- set up Unit, Supplier, Warehouse, Product and related models
- create migrations for inventory tables
- add Filament resources for managing units, suppliers, warehouses, products, damages, warranty items, and movement history
- configure forms and tables with basic fields and relationships
- allow tracking inventory with opening quantity and stock display

## Testing
- `php artisan test` *(fails: `php` not found)*
- `./vendor/bin/pint --dirty` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_b_686c1d05bb7c83229eae3535abf3e3ea